### PR TITLE
fix: fix jsx linting for empty strings

### DIFF
--- a/.changeset/hungry-worms-destroy.md
+++ b/.changeset/hungry-worms-destroy.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-quibble": patch
+---
+
+Fix rule detection for empty strings

--- a/lib/rules/no-excessive-whitespace.js
+++ b/lib/rules/no-excessive-whitespace.js
@@ -80,6 +80,8 @@ export default {
       }
       else {
         switch (argument.type) {
+          case 'Identifier':
+            return
           case 'ArrayExpression':
             argument.elements.forEach((element) => {
               handleNodeArgument(node, element)
@@ -110,7 +112,7 @@ export default {
         }
       }
 
-      if (originalClassNamesValue === null)
+      if (!originalClassNamesValue || originalClassNamesValue.length <= 1)
         return
 
       const classListNoWhitespace = removeWhitespace(originalClassNamesValue)
@@ -144,13 +146,11 @@ export default {
       if (!isNodeClassAttribute(node, classRegex))
         return
 
-      if (isNodeLiteralAttributeValue) {
+      if (isNodeLiteralAttributeValue(node))
         handleNodeArgument(node)
-      }
 
-      else if (node.value && node.value.type === 'JSXExpressionContainer') {
+      else if (node.value && node.value.type === 'JSXExpressionContainer')
         handleNodeArgument(node, node.value.expression)
-      }
     }
 
     const scriptVisitor = {

--- a/lib/utils/stringManipulation.js
+++ b/lib/utils/stringManipulation.js
@@ -13,9 +13,6 @@ export function stringManipulation() {
    * @returns {string | void} - The class list string without excessive whitespace.
    */
   function removeWhitespace(classList) {
-    if (!classList)
-      return
-
     const classListWithWhitespace = classList.split(/(\s+)/)
     const divider = ' '
 

--- a/tests/integrations/playground.jsx
+++ b/tests/integrations/playground.jsx
@@ -5,7 +5,51 @@ export default function HiMyNameIs({
     return str
   }
 
-  const foo = clsx('foo bar baz')
+  function cva(str, obj) {
+    return { str, obj }
+  }
+
+  const cornerVariants = cva('', {
+    variants: {
+      corners: {
+        default: 'rounded-none',
+        roundedTop: 'rounded-t-lg',
+        rounded: 'rounded-lg',
+      },
+    },
+    defaultVariants: {
+      corners: 'default',
+    },
+  })
+
+  const foo = clsx(' ')
+
+  const badgeVariants = cva(
+    'inline-flex items-center text-xs',
+    {
+      variants: {
+        size: {
+          sm: 'min-h-1.5 min-w-1.5 self-center',
+          lg: 'px-2',
+        },
+        variant: {
+          default: 'text-foreground bg-gray-500',
+          primary: 'bg-primary text-primary-foreground',
+          secondary: 'bg-secondary text-primary-foreground',
+          success: 'bg-success text-success-foreground',
+          warning: 'bg-warning text-warning-foreground',
+          destructive: 'bg-destructive text-destructive-foreground',
+        },
+        singleDigit: {
+          true: 'px-1.5',
+        },
+      },
+      defaultVariants: {
+        variant: 'default',
+        size: 'lg',
+      },
+    },
+  )
 
   return (
     <h1 className={clsx('foo bar baz')}>

--- a/tests/lib/rules/no-excessive-whitespace.js
+++ b/tests/lib/rules/no-excessive-whitespace.js
@@ -17,6 +17,38 @@ ruleTester.run('no-excessive-whitespace', rule, {
       code: '<template><div :class="[\'foo\', \'bar\']" /></template>',
     }),
     createTestCase({
+      code: `cva('', {})`,
+    }),
+    createTestCase({
+      code: `
+      const badgeVariants = cva(
+        'inline-flex items-center text-xs',
+        {
+          variants: {
+            size: {
+              sm: 'min-h-1.5 min-w-1.5 self-center',
+              lg: 'px-2',
+            },
+            variant: {
+              default: 'text-foreground bg-gray-500',
+              primary: 'bg-primary text-primary-foreground',
+              secondary: 'bg-secondary text-primary-foreground',
+              success: 'bg-success text-success-foreground',
+              warning: 'bg-warning text-warning-foreground',
+              destructive: 'bg-destructive text-destructive-foreground',
+            },
+            singleDigit: {
+              true: 'px-1.5',
+            },
+          },
+          defaultVariants: {
+            variant: 'default',
+            size: 'lg',
+          },
+        },
+      )`,
+    }),
+    createTestCase({
       code: `
       export default function HiMyNameIs({
           name = 'Hi, my name is -',
@@ -117,6 +149,121 @@ ruleTester.run('no-excessive-whitespace', rule, {
       filename: 'test.jsx',
       options: [{ classRegex: '^quibble$' }],
       errors: createErrors('excessive-whitespace-in-class-attribute'),
+    }),
+    createTestCase({
+      code: `
+      const badgeVariants = cva('inline-flex items-center text-xs',
+        {
+          variants: {
+            size: {
+              sm: 'min-h-1.5 min-w-1.5 self-center ',
+              lg: 'px-2',
+            },
+            variant: {
+              default: ' text-foreground bg-gray-500',
+              primary: ' bg-primary text-primary-foreground',
+              secondary: ' bg-secondary  text-primary-foreground',
+              success: 'bg-success  text-success-foreground',
+              warning: 'bg-warning text-warning-foreground',
+              destructive: 'bg-destructive  text-destructive-foreground',
+            },
+            singleDigit: {
+              true: 'px-1.5',
+            },
+          },
+          defaultVariants: {
+            variant: 'default',
+            size: 'lg',
+          },
+        },
+      )`,
+      output: `
+      const badgeVariants = cva('inline-flex items-center text-xs',
+        {
+          variants: {
+            size: {
+              sm: 'min-h-1.5 min-w-1.5 self-center',
+              lg: 'px-2',
+            },
+            variant: {
+              default: 'text-foreground bg-gray-500',
+              primary: 'bg-primary text-primary-foreground',
+              secondary: 'bg-secondary text-primary-foreground',
+              success: 'bg-success text-success-foreground',
+              warning: 'bg-warning text-warning-foreground',
+              destructive: 'bg-destructive text-destructive-foreground',
+            },
+            singleDigit: {
+              true: 'px-1.5',
+            },
+          },
+          defaultVariants: {
+            variant: 'default',
+            size: 'lg',
+          },
+        },
+      )`,
+      filename: 'test.jsx',
+      errors: createErrors('excessive-whitespace-in-class-attribute', 6),
+    }),
+    createTestCase({
+      code: `
+      const badgeVariants = cva('inline-flex items-center text-xs ',
+        {
+          variants: {
+            size: {
+              sm: 'min-h-1.5 min-w-1.5 self-center ',
+              lg: 'px-2',
+            },
+            variant: {
+              default: ' text-foreground bg-gray-500',
+              primary: ' bg-primary text-primary-foreground',
+              secondary: ' bg-secondary  text-primary-foreground',
+              success: 'bg-success  text-success-foreground',
+              warning: 'bg-warning text-warning-foreground',
+              destructive: 'bg-destructive  text-destructive-foreground',
+            },
+            singleDigit: {
+              true: 'px-1.5',
+            },
+          },
+          defaultVariants: {
+            variant: 'default',
+            size: 'lg',
+          },
+        },
+      )`,
+      output: `
+      const badgeVariants = cva('inline-flex items-center text-xs',
+        {
+          variants: {
+            size: {
+              sm: 'min-h-1.5 min-w-1.5 self-center',
+              lg: 'px-2',
+            },
+            variant: {
+              default: 'text-foreground bg-gray-500',
+              primary: 'bg-primary text-primary-foreground',
+              secondary: 'bg-secondary text-primary-foreground',
+              success: 'bg-success text-success-foreground',
+              warning: 'bg-warning text-warning-foreground',
+              destructive: 'bg-destructive text-destructive-foreground',
+            },
+            singleDigit: {
+              true: 'px-1.5',
+            },
+          },
+          defaultVariants: {
+            variant: 'default',
+            size: 'lg',
+          },
+        },
+      )`,
+      filename: 'test.jsx',
+      errors: [
+        ...createErrors('excessive-whitespace-in-class-callee', 1),
+        ...createErrors('excessive-whitespace-in-class-attribute', 6),
+      ],
     }),
 
     /* -------------------------------


### PR DESCRIPTION
# Fix jsx linting for empty strings
## Description

This PR fixes incorrect linting behaviour for `no-excessive-whitespace` rule when the class string is empty

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The fix was checked in playgrounds and new test cases were added

**Test Configuration**:

- OS + version: e.g. Windows 10
- Node version: 20.11.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
